### PR TITLE
Fix Case of Includes

### DIFF
--- a/src/dialogs/zpropertydialogfoxfile.h
+++ b/src/dialogs/zpropertydialogfoxfile.h
@@ -23,7 +23,7 @@
 #include <QDialog>
 #include "qdataitem.h"
 #include "zallocation_table_model.h"
-#include "zinfotablemodel.h"
+#include "zInfoTableModel.h"
 
 namespace Ui {
 class ZPropertyDialogFoxFile;

--- a/src/model/zInfoTableModel.cpp
+++ b/src/model/zInfoTableModel.cpp
@@ -17,7 +17,7 @@
  *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include "zinfotablemodel.h"
+#include "zInfoTableModel.h"
 
 ZInfoTableModel::ZInfoTableModel(QObject *parent)
   : QAbstractTableModel(parent)

--- a/src/project/zproject_bluray.h
+++ b/src/project/zproject_bluray.h
@@ -20,7 +20,7 @@
 #ifndef ZPROJECT_BLURAY_H
 #define ZPROJECT_BLURAY_H
 
-#include "CommonTreeWidget.h"
+#include "commontreewidget.h"
 
 class ZProjectBluRay : public CommonTreeWidget
 {

--- a/src/project/zproject_videodvd.h
+++ b/src/project/zproject_videodvd.h
@@ -20,7 +20,7 @@
 #ifndef ZPROJECT_VIDEODVD_H
 #define ZPROJECT_VIDEODVD_H
 
-#include "CommonTreeWidget.h"
+#include "commontreewidget.h"
 
 class ZProjectVideoDVD : public CommonTreeWidget
 {

--- a/src/xbelgenerator.h
+++ b/src/xbelgenerator.h
@@ -21,7 +21,7 @@
 #define XBELGENERATOR_H
 
 #include <QTextStream>
-#include "CommonTreeWidget.h"
+#include "commontreewidget.h"
 #include "qdataitem.h"
 
 QT_BEGIN_NAMESPACE

--- a/src/xbelhandler.h
+++ b/src/xbelhandler.h
@@ -22,7 +22,7 @@
 
 #include <QIcon>
 #include <QXmlDefaultHandler>
-#include "CommonTreeWidget.h"
+#include "commontreewidget.h"
 #include "qdataitem.h"
 
 QT_BEGIN_NAMESPACE

--- a/src/zmodules/zimageloader.h
+++ b/src/zmodules/zimageloader.h
@@ -21,7 +21,7 @@
 #define ZIMAGELOADER_H
 
 #include <QIcon>
-#include "CommonTreeWidget.h"
+#include "commontreewidget.h"
 #include "FoxSDKBurningLib.h"
 
 class ZImageLoader

--- a/src/zmodules/zplaylistloader.h
+++ b/src/zmodules/zplaylistloader.h
@@ -21,7 +21,7 @@
 #define ZPLAYLISTLOADER_H
 
 #include <QIcon>
-#include "CommonTreeWidget.h"
+#include "commontreewidget.h"
 #include "qdataitem.h"
 #include "FoxSDKBurningLib.h"
 #include <vector>


### PR DESCRIPTION
Whilst trying to compile the project on Linux I noticed the includes are not all matching the filenames exactly - it appears the letter cases are different.

For instance `#include "CommonTreeWidget.h"` is used instead of `#include "commontreewidget.h"`. This PR resolves these case issues.
