### PR TITLE
sscanf_s is a Windows Only Function

### DIFF
--- a/src/utils/utils_common.cpp
+++ b/src/utils/utils_common.cpp
@@ -134,7 +134,12 @@ QString MSFInt32ToStr(int32 index)
 int32 MSFStrToInt32(QString str)
 {
     int minutes, seconds, frames;
+#if defined (WIN32)
     sscanf_s(str.toStdString().c_str(), "%02d:%02d:%02d", &minutes, &seconds, &frames);
+#else
+    sscanf(str.toStdString().c_str(), "%02d:%02d:%02d", &minutes, &seconds, &frames);
+#endif
+    
     return MSFToInt32(minutes, seconds, frames);
 }
 


### PR DESCRIPTION
Whilst trying to compile the project on Linux I noticed the use of `sscanf_s` function. This function is only available on Windows but a simple define is enough to allow compilation to continue.