### PR TITLE
Add Qt Version Requirements to QMake File

### DIFF
--- a/src/diskbutler.pro
+++ b/src/diskbutler.pro
@@ -9,7 +9,12 @@ QT       += gui
 QT       += widgets
 QT       += xml
 QT       += network
-QT       += core5compat
+
+greaterThan(QT_MAJOR_VERSION, 6) {
+    QT       += core5compat
+}
+
+!versionAtLeast(QT_VERSION, 5.15):error("Use at least Qt version 5.15")
 
 VERSION = 2.4.7.6
 


### PR DESCRIPTION
I think it would make sense to add minimum version requirements to the QMake file, for instance core5compat is only relevant for Qt6 and [due to the use of Qt::endl](https://bugreports.qt.io/browse/QTBUG-82680) at least Qt5.15 must be used.