### PR TITLE
Fix Some Comparison Methods Errors

### DIFF
--- a/src/commontreewidget.cpp
+++ b/src/commontreewidget.cpp
@@ -1990,7 +1990,7 @@ bool CommonTreeWidget::isFiltered(QFileInfo info)
     QDate to = QDate::fromString(diskItem->getDateTo());
 
     if (diskItem->getByDate()) {
-        if (operator>=(create,from) && operator <=(create,to)) {
+        if ((create>=from) && (create<=to)) {
             return true;
         }
     } else {

--- a/src/settingspages.cpp
+++ b/src/settingspages.cpp
@@ -588,7 +588,7 @@ bool PluginPage::readPlugins()
         it.next();
 
 #if defined (LINUX)
-        compare(str1, str2, Qt::CaseInsensitive);
+        //compare(str1, str2, Qt::CaseInsensitive);
         if(it.fileInfo().completeSuffix().compare("so",Qt::CaseInsensitive)==0){
             pluginsSub(it.fileName(), it.filePath(), excludeList);
         }


### PR DESCRIPTION
Some comparison functions in the code were throwing errors when compiling, the changes in this PR are minor and do not result in a behaviour change.